### PR TITLE
fix: disable OTEL tracing for cost reduction

### DIFF
--- a/k8s/base/fciv-net/configmap.yaml
+++ b/k8s/base/fciv-net/configmap.yaml
@@ -29,6 +29,6 @@ data:
   log-level: "info"
 
   # Distributed Tracing (OpenTelemetry with GCP Cloud Trace)
-  # Set to "true" to enable trace export to Cloud Trace
+  # Disabled for cost reduction (maintenance mode). Set to "true" to re-enable.
   # Requires roles/cloudtrace.agent on the service account
-  enable-cloud-trace: "true"
+  enable-cloud-trace: "false"

--- a/k8s/base/fciv-net/deployment.yaml
+++ b/k8s/base/fciv-net/deployment.yaml
@@ -157,9 +157,12 @@ spec:
 
             # Distributed tracing disabled for cost reduction (maintenance mode)
             # OTLP collector is no longer deployed — traces fall back to basic logging
-            # To re-enable: uncomment env vars below and set enable-cloud-trace to "true"
+            # To re-enable: uncomment OTLP_ENDPOINT below and set enable-cloud-trace to "true" in configmap
             - name: ENABLE_CLOUD_TRACE
-              value: "false"
+              valueFrom:
+                configMapKeyRef:
+                  name: fciv-net-config
+                  key: enable-cloud-trace
             # - name: OTLP_ENDPOINT
             #   value: "http://opentelemetry-collector.opentelemetry.svc.cluster.local:4317"
             # Resource attributes - patched per environment (staging default)

--- a/k8s/base/fciv-net/deployment.yaml
+++ b/k8s/base/fciv-net/deployment.yaml
@@ -155,15 +155,13 @@ spec:
             - name: GATEWAY_STALE_GAME_WARN_THRESHOLD
               value: "3600"
 
-            # Distributed tracing (OpenTelemetry with GCP Cloud Trace)
+            # Distributed tracing disabled for cost reduction (maintenance mode)
+            # OTLP collector is no longer deployed — traces fall back to basic logging
+            # To re-enable: uncomment env vars below and set enable-cloud-trace to "true"
             - name: ENABLE_CLOUD_TRACE
-              valueFrom:
-                configMapKeyRef:
-                  name: fciv-net-config
-                  key: enable-cloud-trace
-            # OTLP endpoint for OpenTelemetry (in-cluster collector)
-            - name: OTLP_ENDPOINT
-              value: "http://opentelemetry-collector.opentelemetry.svc.cluster.local:4317"
+              value: "false"
+            # - name: OTLP_ENDPOINT
+            #   value: "http://opentelemetry-collector.opentelemetry.svc.cluster.local:4317"
             # Resource attributes - patched per environment (staging default)
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: "gcp.project_id=clashai-staging"


### PR DESCRIPTION
## Summary

Disables OpenTelemetry tracing in FreeCiv to match the OTEL collector removal in agent-clash (PR #437).

- Set `ENABLE_CLOUD_TRACE` to `"false"` in both configmap and deployment
- Comment out `OTLP_ENDPOINT` — the collector is no longer deployed
- Keep `OTEL_RESOURCE_ATTRIBUTES` and `GOOGLE_CLOUD_PROJECT` for Cloud Logging attribution

### Why

The OTEL collector was removed from both staging and production environments in agent-clash as part of maintenance mode cost reduction. Without this change, FreeCiv logs connection errors on every trace export attempt.

### Reversibility

All changes have inline re-enable comments. To restore tracing:
1. Re-deploy the OTEL collector in agent-clash
2. Set `enable-cloud-trace` back to `"true"`
3. Uncomment `OTLP_ENDPOINT`

## Test plan

- [ ] Verify FreeCiv pods start without OTLP connection errors after deploy
- [ ] Verify game functionality unaffected (tracing is observability-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)